### PR TITLE
Add why higgsboson section on top of contributors section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+
+# Vscode conf files
+.vscode

--- a/src/components/component-hero.webc
+++ b/src/components/component-hero.webc
@@ -19,6 +19,13 @@
 
   @media (max-width: 700px) {
     .hggsw-header .hggs-h1 {
+      font-size: 45px;
+      line-height: 45px;
+    }
+  }
+
+  @media (max-width: 350px) {
+    .hggsw-header .hggs-h1 {
       font-size: 35px;
       line-height: 35px;
     }

--- a/src/components/component-main.webc
+++ b/src/components/component-main.webc
@@ -1,5 +1,6 @@
 <main class="hggsw-main hggs-flex hggs-flex--column-top-center">
   <component-hero webc:nokeep></component-hero>
+  <component-why-higgsboson-reasons webc:nokeep></component-why-higgsboson-reasons>
   <component-contributors webc:nokeep></component-contributors>
 </main>
 
@@ -7,12 +8,7 @@
   .hggsw-main {
     padding-left: calc(3 * var(--hggs-space-lg-default));
     padding-right: calc(3 * var(--hggs-space-lg-default));
-    gap: var(--hggs-space-md-default)
-  }
-
-  .hggsw-main section {
-    margin-top: calc(var(--hggs-space-md-default)/2);
-    margin-bottom: calc(var(--hggs-space-md-default)/2);
+    gap: var(--hggs-space-default)
   }
 
   .hggsw-main section h3 {
@@ -20,7 +16,7 @@
     margin-bottom: var(--hggs-space-md-default);
   }
 
-  @media (max-width: 700px) {
+  @media (max-width: 1100px) {
     .hggsw-main {
       padding-left: var(--hggs-space-default);
       padding-right: var(--hggs-space-default);

--- a/src/components/component-why-higgsboson-reason.webc
+++ b/src/components/component-why-higgsboson-reason.webc
@@ -1,0 +1,4 @@
+<slot name="hggsw-why-higgsboson-reason-title"></slot>
+<slot name="hggsw-why-higgsboson-reason-description"></slot>
+
+

--- a/src/components/component-why-higgsboson-reasons.webc
+++ b/src/components/component-why-higgsboson-reasons.webc
@@ -1,0 +1,104 @@
+<section class="hggsw-why-higgsboson-reasons hggs-flex--row-center">
+  <header>
+    <h3 class="hggs-h3">Why Higgsboson?</h3>
+  </header>
+  <ul class="hggsw-why-higgsboson-reasons-list">
+    <component-why-higgsboson-reason webc:for="reason of [{
+        title: 'Use the web.',
+        description: 'Be the most standard as possible. CSS already has enough capabilities to not need anymore preprocessors capabilities.'
+      },{
+        title: 'Independent pieces.',
+        description: 'Minimum coupling between internal parts. Use hooks to connect the components with the different themes.'
+      },
+      {
+        title: 'Single responsibility.',
+        description: 'Driven by single responsibility, intuitively take control over what, where and how to make your changes.'
+      },
+      {
+        title: 'Evolve it fast.',
+        description: 'Evolve it strongly by propagate changes quickly. Use CSS native cascading inheritance and specificity to your advantage.'
+      },
+      {
+        title: 'Design system ready.',
+        description: 'Developed from a tokens layer, makes it easy to adapt and implement the aesthetic part to any design system.'
+      },
+      {
+        title: 'No coupling.',
+        description: 'No JS framework coupling, independent but easily implementable with any library or front end framework.'
+      }]">
+      <li class="hggsw-why-higgsboson-reason">
+        <h4
+          class="hggs-h4"
+          slot="hggsw-why-higgsboson-reason-title"
+          webc:for="(key, value) in reason"
+          webc:if="key === 'title'"
+          @text="value"
+        >
+        </h4>
+        <p
+          class="hggs-text"
+          slot="hggsw-why-higgsboson-reason-description"
+          webc:for="(key, value) in reason"
+          webc:if="key === 'description'"
+          @text="value"
+        >
+        </p>
+      </li>
+    </component-why-higgsboson-reason>
+  </ul>
+</section>
+
+<style>
+  .hggsw-why-higgsboson-reasons-list {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    align-items: center;
+    column-gap: var(--hggs-space-md-default);
+    row-gap: var(--hggs-space-default);
+    margin: 0;
+    padding-left: 0;
+  }
+
+  .hggsw-why-higgsboson-reason {
+    display: block;
+    flex-direction: column;
+    flex: 1 1 30%;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: flex-start;;
+  }
+
+  .hggsw-why-higgsboson-reason .hggs-h4 {
+    margin-top: 0;
+  }
+
+  @media (max-width: 1100px) {
+    .hggsw-why-higgsboson-reasons-list  {
+      flex-direction: column;
+      align-items: flex-start;
+      justify-content: flex-start;
+    }
+
+    .hggsw-why-higgsboson-reason {
+      align-items: center;
+      justify-content: flex-start;
+    }
+
+    .hggsw-why-higgsboson-reason .hggs-h4 {
+      text-align: center;
+    }
+
+    .hggsw-why-higgsboson-reason .hggs-text {
+      text-align: center;
+      width: 60%;
+    }
+  }
+
+  @media (max-width: 700px) {
+    .hggsw-why-higgsboson-reason .hggs-text {
+      width: 100%;
+    }
+  }
+</style>


### PR DESCRIPTION
# Title
8 add why higgsboson section on top of contributors section

## Issue
#8 

## Description

Set some bullet points about why is good idea to use higgsboson

    * The most standard way possible, use the web.
    * Minimum coupling between internal parts.
    * Oriented to his main responsibility, styling pieces on the screen.
    * Fully customizable injectable themes.
    * Fast propagation of changes.
    * Easily articulated in a design system.
    * Independent but easily implementable in any library or front end framework.

## Summary of changes

- [x] Add why higgsboson reason and reasons components
- [x] Adjust some breakpoints in main, navigations and app components

## Screenshots

![localhost_8080_ (1)](https://github.com/javierlopezdeancos/higgsboson-web/assets/1202463/d98f44d1-0fc2-419f-80bf-4be713534f26)
 
